### PR TITLE
Fixing scan_table iterator to include the 'ExclusiveStartKey' : 'LastEvalua…

### DIFF
--- a/socks/dynamodb.py
+++ b/socks/dynamodb.py
@@ -135,7 +135,10 @@ def scan_table(table_name, session=boto3, region_name='us-east-1', **dynamo_tabl
 
         # Continue scanning if there are more records
         while 'LastEvaluatedKey' in response:
-            response = table.scan()
+            scan_kwargs = {'ExclusiveStartKey':response['LastEvaluatedKey']}
+            for kwarg in dynamo_table_scan_kwargs:
+                scan_kwargs[kwarg] = dynamo_table_scan_kwargs[kwarg]
+            response = table.scan(**scan_kwargs)
             for i in response['Items']:
                 results.append(json.dumps(i, cls=DecimalEncoder))
 


### PR DESCRIPTION
I changed it so that it includes the 'ExclusiveStartKey' : 'LastEvaluatedKey' kwarg and also preserves any user-provided kwargs